### PR TITLE
Improve help for browse mode controls

### DIFF
--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -12,7 +12,7 @@ import globalPluginHandler
 import controlTypes
 import ui
 import api
-from virtualBuffers import VirtualBuffer
+from browseMode import BrowseModeDocumentTreeInterceptor
 import scriptHandler
 from .controltypeshelp import controlTypeHelpMessages, browseModeHelpMessages
 from .nvdaobjectshelp import objectsHelpMessages
@@ -57,9 +57,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Except for virtual buffers, do not proceed if we do have help messages from MRO lookup.
 		# Additional constraints.
 		# Just in case browse mode is active.
-		if isinstance(curObj.treeInterceptor, VirtualBuffer):
+		if isinstance(curObj.treeInterceptor, BrowseModeDocumentTreeInterceptor):
 			# In case we're dealing with virtual buffer, call the below method.
-			helpMessages.append(self.VBufHelp(curObj))
+			helpMessages.append(self.VBufHelp(curObj.treeInterceptor.currentNVDAObject))
 		if len(helpMessages) == CUAMROLevel:
 			if curObj.role in controlTypeHelpMessages:
 				helpMessages.append(controlTypeHelpMessages[curObj.role])


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Some controls like links in browse mode can be activated when cursor is placed at their positions, and focus can be in a different place, so it's better to provide help for the current object in browse mode.
### Description of how this pull request fixes the issue:
If we're in browse mode:
helpMessages.append(self.VBufHelp(curObj.treeInterceptor.currentNVDAObject))

### Testing performed:
Tested locally, placing the cursor in elements like a link while the focus is in a different place like combo box.
### Known issues with pull request:
None.
### Change log entry:
* Improved support for objects in browse mode.