### PR TITLE
Add support for automatic messages based in roles

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,0 +1,41 @@
+name: Check for MyPy type hints
+
+on:
+
+  push:
+  
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  mypy:
+    runs-on: windows-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: pip install mypy
+    - name: MyPy
+      run: python -m mypy addon
+    - name: Comment on PR
+      uses: actions/github-script@v3
+      if: failure()
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'This PR introduces MyPy errors'
+          })
+          

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -145,17 +145,19 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def event_loseFocus(self, obj, nextHandler):
 		nextHandler()
-		if self.shouldGetHelpAutomaticMessage:
+		if self.shouldGetHelpAutomaticMessage():
 			self.prevObj = obj
 
 	def event_gainFocus(self, obj, nextHandler):
 		nextHandler()
-		if not self.shouldGetHelpAutomaticMessage:
+		if not self.shouldGetHelpAutomaticMessage():
 			return
 		ti = obj.treeInterceptor
-		if isinstance(ti, BrowseModeDocumentTreeInterceptor) and not ti.passThrough:
+		if isinstance(ti, BrowseModeDocumentTreeInterceptor):
 			return
 		if obj.role == self.prevObj.role:
+			return
+		if obj.role == controlTypes.Role.EDITABLETEXT and controlTypes.State.READONLY in obj.states:
 			return
 		if self.prevObj.role == controlTypes.Role.POPUPMENU and obj.role == controlTypes.Role.MENUITEM:
 			return

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -111,8 +111,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			if not obj.treeInterceptor.passThrough:
 				VBufmsg = browseModeHelpMessages[obj.role]
 			else:
-				# Translators: Help message for reading a webpage while in focus mode.
 				VBufmsg = _(
+					# Translators: Help message for reading a webpage while in focus mode.
 					"To use browse mode and quick navigation keys to read the webpage, "
 					"switch to browse mode by pressing NVDA+SPACE"
 				)
@@ -120,6 +120,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			try:
 				VBufmsg = controlTypeHelpMessages[obj.role]
 			except KeyError:
+				# Translators: Message presented when there's no help for this control.
 				VBufmsg = _("No help for this control")
 		return VBufmsg
 

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -145,6 +145,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def event_loseFocus(self, obj, nextHandler):
 		nextHandler()
+		ti = obj.treeInterceptor
+		if isinstance(ti, BrowseModeDocumentTreeInterceptor):
+			return
 		if self.shouldGetHelpAutomaticMessage():
 			self.prevObj = obj
 

--- a/addon/globalPlugins/controlUsageAssistant/controltypeshelp.py
+++ b/addon/globalPlugins/controlUsageAssistant/controltypeshelp.py
@@ -7,8 +7,11 @@
 # If specific states are found, help messages will come from state-specific subsets.
 
 import controlTypes
+from typing import Callable
 import addonHandler
 addonHandler.initTranslation()
+
+_: Callable[[str], str]
 
 # Default help messages for controls: key = role, value = messages.
 # Source: NVDA pull request for issue 2699 (context-sensitive help)

--- a/addon/globalPlugins/controlUsageAssistant/nvdaobjectshelp.py
+++ b/addon/globalPlugins/controlUsageAssistant/nvdaobjectshelp.py
@@ -7,8 +7,11 @@
 # This module also serves as a home for messages for overlay classes found in app modules and global plugins.
 # Other add-ons should update this dictionary with help messages for their own overlay classes.
 
+from typing import Callable
 import addonHandler
 addonHandler.initTranslation()
+
+_: Callable[[str], str]
 
 # Help messages for objects: key = string representation of a class name, value = generic help message.
 # Base API classes (such as NVDAObjects.NVDAObject) are not included.

--- a/addon/globalPlugins/controlUsageAssistant/utils.py
+++ b/addon/globalPlugins/controlUsageAssistant/utils.py
@@ -1,0 +1,70 @@
+import gui
+from gui import SettingsPanel, guiHelper
+import config
+from typing import Dict
+from speech import types
+from typing import Callable
+import addonHandler
+
+addonHandler.initTranslation()
+
+_: Callable[[str], str]
+
+ADDON_SUMMARY = addonHandler.getCodeAddon().manifest["summary"]
+
+confspec: Dict[str, str] = {
+	"speech": "boolean(default=False)",
+	"braille": "boolean(default=False)",
+	"pitch": "integer(default=0)"
+}
+
+
+def getAutomaticSpeechSequence(message: str, speechCommand=None) -> types.SpeechSequence:
+	sequence = []
+	if speechCommand is not None:
+		sequence.append(speechCommand)
+	sequence.append(message)
+	return sequence
+
+
+class AddonSettingsPanel(SettingsPanel):
+
+	title = ADDON_SUMMARY
+
+	def makeSettings(self, settingsSizer):
+		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		# Translators: label of a dialog.
+		outputModesLabel = _("Sele&ct output modes for automatic messages")
+		outputModesChoices = [
+			# Translators: label of a dialog.
+			_("Speech"),
+			# Translators: label of a dialog.
+			_("Braille"),
+		]
+		self.outputModesList = sHelper.addLabeledControl(
+			outputModesLabel, gui.nvdaControls.CustomCheckListBox, choices=outputModesChoices
+		)
+		checkedItems = []
+		if config.conf["controlUsageAssistant"]["speech"]:
+			checkedItems.append(0)
+		if config.conf["controlUsageAssistant"]["braille"]:
+			checkedItems.append(1)
+		self.outputModesList.CheckedItems = checkedItems
+		self.outputModesList.Select(0)
+		# Translators: label of a dialog.
+		pitchLabel = _("&Pitch change for automatic messages")
+		self.pitchEdit = sHelper.addLabeledControl(
+			pitchLabel,
+			gui.nvdaControls.SelectOnFocusSpinCtrl,
+			min=-30,
+			max=30,
+			initial=config.conf["controlUsageAssistant"]["pitch"]
+		)
+
+	def postInit(self):
+		self.outputModesList.SetFocus()
+
+	def onSave(self):
+		config.conf["controlUsageAssistant"]["speech"] = self.outputModesList.IsChecked(0)
+		config.conf["controlUsageAssistant"]["braille"] = self.outputModesList.IsChecked(1)
+		config.conf["controlUsageAssistant"]["pitch"] = self.pitchEdit.GetValue()


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Sometimes, when pressing NVDA+h and then Escape, the control for we want to get help is closed, for example in menus. So automatic messages maybe convenient.
### Description of how this pull request fixes the issue:
In the global plugin, event_loadFocus is used to hold the previous object with focus and, if role is not the same in the focused object, and automatic messages are set to be spoken or displayed in Braille, NVDA will report messages based on roles.
A utils.py nodule has been added with a function to retrieve a speech sequence with a command (pitch option is available) and a message. Also this file contains a panel which is added to NVDA settings for this add-on
### Testing performed:
Tested locally
### Known issues with pull request:
None
### Change log entry:
* Added support for automatic messages.