### PR TITLE
Update readme and buildVars

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Author: Joseph Lee, Noelia Ruiz Martínez
 * Download [stable version][1]
-* NVDA compatibility: 2021.3 and later
+* NVDA compatibility: 2022.1 and later
 
 Use this add-on to find out how to interact with the focused control.
 Press NVDA+H to obtain a short help message on interacting with the focused control, such as checkboxes, edit fields and so on.
@@ -10,7 +10,7 @@ Press NVDA+H to obtain a short help message on interacting with the focused cont
 Go to NVDA's menu, Preferences submenu, Settings dialog, Control Usage Asistant category to configure add-on settings:
 
 * Select output modes for automatic messages: This list of checkboxes allows to select speech and braille.
-* Pitch change for automatic messages: This spin box allows to set the pitch change when NVDA reads automatic messages.
+* Pitch change for automatic messages: This spin box allows to set the pitch change when NVDA reads automatic messages (from -30 to +30).
 
 ## Note
 
@@ -18,7 +18,7 @@ Be aware: automatic messages shouldn't be spoken in documents that support brows
 
 ## Version 2022.03.27
 
-* Compatible with NVDA 2021.3 and later.
+* Requires NVDA 2021.3 and later.
 
 ## Version 22.01
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,28 @@
 
 * Author: Joseph Lee, Noelia Ruiz Martínez
 * Download [stable version][1]
-* NVDA compatibility: 2021.2 and later
+* NVDA compatibility: 2021.3 and later
 
 Use this add-on to find out how to interact with the focused control.
 Press NVDA+H to obtain a short help message on interacting with the focused control, such as checkboxes, edit fields and so on.
 
 Go to NVDA's menu, Preferences submenu, Settings dialog, Control Usage Asistant category to configure add-on settings:
 
-- Select output modes for automatic messages: This list of checkboxes allows to select speech and braille.
-- Pitch change for automatic messages: This spin box allows to set the pitch change when NVDA reads automatic messages.
+* Select output modes for automatic messages: This list of checkboxes allows to select speech and braille.
+* Pitch change for automatic messages: This spin box allows to set the pitch change when NVDA reads automatic messages.
+
+## Note
+
+Be aware: automatic messages shouldn't be spoken in documents that support browse mode, but sometimes this cannot be avoided due to focus changes. To prevent this, you can disable these messages for specific applications using NVDA's configuration profiles.
+
+## Version 2022.03.27
+
+* Compatible with NVDA 2021.3 and later.
 
 ## Version 22.01
 
-* Add support for automatic messages.
-* Improve support for requested messages in browse mode.
+* Added support for automatic messages.
+* Improved support for requested messages in browse mode.
 
 ## Version 21.10
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -34,9 +34,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "2021.2",
+	"addon_minimumNVDAVersion": "2021.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2021.3",
+	"addon_lastTestedNVDAVersion": "2022.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!

--- a/buildVars.py
+++ b/buildVars.py
@@ -34,7 +34,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "2021.3",
+	"addon_minimumNVDAVersion": "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2022.1",
 	# Add-on update channel (default is None, denoting stable releases,


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
Update for NVDA 2022.1
### Description of how this pull request fixes the issue:
BuldVars, copyrights for utils and __init__.py and readme have been updated. Also, imports have been reordered for readability.
### Testing performed:
None with this precise repo. I'll test with the generated artifact before merging
### Known issues with pull request:
None.
### Change log entry:
NOne: readme has been updated.