### PR TITLE
Report automatic messages for applications, not just based on roles

### DIFF
--- a/addon/globalPlugins/controlUsageAssistant/utils.py
+++ b/addon/globalPlugins/controlUsageAssistant/utils.py
@@ -4,7 +4,7 @@
 # Copyright 2022 Noelia Ruiz Martínez
 # Released under GPL
 
-from typing import Dict
+from typing import Dict, Optional
 from typing import Callable
 
 import gui
@@ -26,12 +26,13 @@ confspec: Dict[str, str] = {
 }
 
 
-def getAutomaticSpeechSequence(message: str, speechCommand=None) -> types.SpeechSequence:
+def getAutomaticSpeechSequence(message: str, speechCommand=None) -> Optional[types.SpeechSequence]:
 	sequence = []
 	if speechCommand is not None:
 		sequence.append(speechCommand)
 	sequence.append(message)
-	return sequence
+	if message:
+		return sequence
 
 
 class AddonSettingsPanel(SettingsPanel):


### PR DESCRIPTION
## Link to issue number:
Fixes issue #4 
### Summary of the issue:
Automatic messages are based on object roles, ignoring help for specific applications like Excel or Power-Point
### Description of how this pull request fixes the issue:
- Created a function to get messages for applications, using roles as fallback.
- Created a variable to get the last message reported automatically.
- - Removed event_loseFocus function, since repeated messages are avoided based on previous spoken message, not in previous object. This seems to fix an issue where sometimes automatic messages were reported in browse mode.
- - Tweaked function that gets the speech sequence for automatic messages to prevent errors when message is None.
### Testing performed:
Tested locally in Excel and Power-Point.
### Known issues with pull request:
- Messages are reported when a context menu is open and then when arrows are pressed. These messages are similar but not the same, and previously this was prevented since we considered the previous object, not the previous spoken message. Anyway this may acceptable or fixed later.
### Change log entry:
None: this is a dev version, not stable.