### PR TITLE
Add ability to receive automatic messages in object navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Press NVDA+H to obtain a short help message on interacting with the focused cont
 
 Go to NVDA's menu, Preferences submenu, Settings dialog, Control Usage Asistant category to configure add-on settings:
 
+* Automatic messages for focus: Checked by default.
+* Type the message to be used when an object can be activated: You may include a short message indicating the default or your configured gesture to know if the current object has an associated action when pressing a gesture like NVDA+enter in object navigation.
 * Select output modes for automatic messages: This list of checkboxes allows to select speech and braille.
 * Pitch change for automatic messages: This spin box allows to set the pitch change when NVDA reads automatic messages (from -30 to +30).
 

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -189,7 +189,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 		message = None
 		try:
-			realActionName = obj.getActionName()
+			obj.getActionName()
 			message = self.getMessageForClickableObject()
 		except Exception:
 			if obj.isFocusable:

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -154,9 +154,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return True
 		return False
 
-	def reportAutomaticHelpMessage(self, obj):
+	def reportMessage(self, message):
 		settings = config.conf["controlUsageAssistant"]
-		if not settings["speech"] and not settings["braille"]:
+		if settings["speech"]:
+			speechSequence = getAutomaticSpeechSequence(message, PitchCommand(settings["pitch"]))
+			speech.speak(speechSequence)
+		if settings["braille"]:
+			braille.handler.message(message)
+
+	def reportAutomaticHelpMessage(self, obj):
+		if not self.shouldGetHelpAutomaticMessage():
 			return
 		try:
 			message = self.getAutomaticHelpMessage(obj)
@@ -164,15 +171,28 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 		if message == self.automaticHelpMessage:
 			return
-		if settings["speech"]:
-			speechSequence = getAutomaticSpeechSequence(message, PitchCommand(settings["pitch"]))
-			speech.speak(speechSequence)
-		if settings["braille"]:
-			braille.handler.message(message)
+		self.reportMessage(message)
 		self.automaticHelpMessage = message
 
 	def event_gainFocus(self, obj, nextHandler):
 		nextHandler()
-		if not self.shouldGetHelpAutomaticMessage():
+		if not config.conf["controlUsageAssistant"]["focusMessages"] or not self.shouldGetHelpAutomaticMessage():
 			return
 		self.reportAutomaticHelpMessage(obj)
+
+	def getMessageForClickableObject(self):
+		return config.conf["controlUsageAssistant"]["clickableObjectMessage"]
+
+	def event_becomeNavigatorObject(self, obj, nextHandler, isFocus):
+		nextHandler()
+		if isFocus or not self.shouldGetHelpAutomaticMessage():
+			return
+		message = None
+		try:
+			realActionName = obj.getActionName()
+			message = self.getMessageForClickableObject()
+		except Exception:
+			if obj.isFocusable:
+				message = self.getMessageForFocusableObject()
+		if message:
+			self.reportMessage(message)

--- a/addon/globalPlugins/controlUsageAssistant/utils.py
+++ b/addon/globalPlugins/controlUsageAssistant/utils.py
@@ -88,4 +88,3 @@ class AddonSettingsPanel(SettingsPanel):
 		config.conf["controlUsageAssistant"]["speech"] = self.outputModesList.IsChecked(0)
 		config.conf["controlUsageAssistant"]["braille"] = self.outputModesList.IsChecked(1)
 		config.conf["controlUsageAssistant"]["pitch"] = self.pitchEdit.GetValue()
-

--- a/addon/globalPlugins/controlUsageAssistant/utils.py
+++ b/addon/globalPlugins/controlUsageAssistant/utils.py
@@ -4,6 +4,7 @@
 # Copyright 2022 Noelia Ruiz Martínez
 # Released under GPL
 
+import wx
 from typing import Dict, Optional
 from typing import Callable
 
@@ -20,9 +21,11 @@ _: Callable[[str], str]
 ADDON_SUMMARY = addonHandler.getCodeAddon().manifest["summary"]
 
 confspec: Dict[str, str] = {
+	"focusMessages": "boolean(default=True)",
+	"clickableObjectMessage": "string(default="")",
 	"speech": "boolean(default=False)",
 	"braille": "boolean(default=False)",
-	"pitch": "integer(default=0)"
+	"pitch": "integer(default=0)",
 }
 
 
@@ -41,6 +44,16 @@ class AddonSettingsPanel(SettingsPanel):
 
 	def makeSettings(self, settingsSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		# Translators: label of a dialog.
+		self.focusMessagesCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("&Automatic messages for focus")))
+		self.focusMessagesCheckBox.SetValue(config.conf["controlUsageAssistant"]["focusMessages"])
+		# Translators: label of a dialog.
+		setClickableObjLabel = _("Type the message to be used when an object can be activated")
+		self.setClickableObjEdit = sHelper.addLabeledControl(setClickableObjLabel, wx.TextCtrl)
+		try:
+			self.setClickableObjEdit.SetValue(config.conf["controlUsageAssistant"]["clickableObjectMessage"])
+		except Exception:
+			self.setClickableObjEdit.SetValue("")
 		# Translators: label of a dialog.
 		outputModesLabel = _("Sele&ct output modes for automatic messages")
 		outputModesChoices = [
@@ -69,10 +82,10 @@ class AddonSettingsPanel(SettingsPanel):
 			initial=config.conf["controlUsageAssistant"]["pitch"]
 		)
 
-	def postInit(self):
-		self.outputModesList.SetFocus()
-
 	def onSave(self):
+		config.conf["controlUsageAssistant"]["focusMessages"] = self.focusMessagesCheckBox.GetValue()
+		config.conf["controlUsageAssistant"]["clickableObjectMessage"] = self.setClickableObjEdit.GetValue()
 		config.conf["controlUsageAssistant"]["speech"] = self.outputModesList.IsChecked(0)
 		config.conf["controlUsageAssistant"]["braille"] = self.outputModesList.IsChecked(1)
 		config.conf["controlUsageAssistant"]["pitch"] = self.pitchEdit.GetValue()
+


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Closes issue #6 
### Summary of the issue:
Users may want to read automatic messages in object navigation.
### Description of how this pull request fixes the issue:
The add-on settings panel has a checkbox to configure if automatic messages forfocus are desired, as well as an edit box to select the message that should be reported if the object navigator can be activated. A method to report generic messages has been added to be used for different events, as well as a method to get the message configured for object navigation, and event_becomeNavigatorObject method is responsible for the new feature.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
* Added ability to report automatic messages in object navigation.