### PR TITLE
Don't report message for object navigation in emoji panel

### DIFF
--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -185,7 +185,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def event_becomeNavigatorObject(self, obj, nextHandler, isFocus):
 		nextHandler()
-		if isFocus or not self.shouldGetHelpAutomaticMessage():
+		if isFocus or not self.shouldGetHelpAutomaticMessage() or obj.appModule.productName == 'MicrosoftWindows.Client.CBS':
 			return
 		message = None
 		try:

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -185,7 +185,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def event_becomeNavigatorObject(self, obj, nextHandler, isFocus):
 		nextHandler()
-		if isFocus or not self.shouldGetHelpAutomaticMessage() or obj.appModule.productName == 'MicrosoftWindows.Client.CBS':
+		if (
+			isFocus or not self.shouldGetHelpAutomaticMessage()
+			or obj.appModule.productName == 'MicrosoftWindows.Client.CBS'
+		):
 			return
 		message = None
 		try:


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Related to issue #6 
### Summary of the issue:
In emoji panel, when it's opened or arrows are moved to select emojis, the message for objects which can be activated can be reported when it's not desired.
### Description of how this pull request fixes the issue:
Disable this feature when obj.appModule.productName=='MicrosoftWindows.Client.CBS'.

### Testing performed:
Tested locally using the emoji panel.
### Known issues with pull request:
None, but this should be tested.
### Change log entry:
None: we don't specify all cases addressed in this feature, for example when the object navigator has the focus.