### PR TITLE
Report clickable objects after speaking other obj properties

### DIFF
--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -5,6 +5,8 @@
 # Copyright 2013-2022 Joseph Lee, Noelia Ruiz Martínez
 # Released under GPL.
 
+import wx
+
 import speech
 
 # NVDA+H: Obtain usage help on a particular control.
@@ -197,4 +199,4 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		except Exception:
 			pass
 		if message:
-			self.reportMessage(message)
+			wx.CallAfter(self.reportMessage, message)


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Addresses comment on issue #6
### Summary of the issue:
Clickable objects are reported before NVDA speaks other properties, and this may not be comfortable.
### Description of how this pull request fixes the issue:
Use wx.CallAfter to report the message.
### Testing performed:
Tested manually.
### Known issues with pull request:
None
### Change log entry:
* The message configured for clickable objects will be reported after other properties.