### PR TITLE
Add  compatibility with NVDA 2024.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -36,7 +36,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2023.2",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.2",
+	"addon_lastTestedNVDAVersion": "2024.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
NVDA 2024.1 will be a breaking compatibility release.
### Description of how this pull request fixes the issue:
Updated last tested version in buildVars.py.
### Testing performed:
Testedlocally.
### Known issues with pull request:
None
### Change log entry:
None