### PR TITLE
Enhance support for edit boxes and suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Go to NVDA's menu, Preferences submenu, Settings dialog, Control Usage Asistant 
 * Select output modes for automatic messages: This list of checkboxes allows to select speech and braille.
 * Pitch change for automatic messages: This spin box allows to set the pitch change when NVDA reads automatic messages (from -30 to +30).
 
+## Version 2024.03.24
+
+* Improved support for edit controls and suggestions.
+
 ## Version 2023.02.19
 
 * The message configured for clickable objects will be reported after other properties.

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -44,19 +44,17 @@ _: Callable[[str], str]
 # before resorting to role-based messages.
 CUAMROLevel = 0
 
-shouldReportSuggestion = False
-
-
 class EnhancedSuggestion(NVDAObjects.behaviors.InputFieldWithSuggestions):
 
 	def event_suggestionsOpened(self):
 		super().event_suggestionsOpened()
-		global shouldReportSuggestion
-		shouldReportSuggestion = True
+		self.helpText = (
+			# Translators: help text for search field in Windows 10 and other places.
+		 _("After typing search text, press up or down arrow keys to review list of suggestions.")
+			)
 
 	def event_suggestionsClosed(self):
-		global shouldReportSuggestion
-		shouldReportSuggestion = False
+		self.helpText = None
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
@@ -109,11 +107,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				clsName = str(entry).split("'")[1]
 				if clsName in objectsHelpMessages:
 					helpMessages.append(objectsHelpMessages[clsName])
-		if shouldReportSuggestion:
-			helpMessages = [
-				# Translators: help text for search field in Windows 10 and other places.
-		 _("After typing search text, press up or down arrow keys to review list of suggestions.")
-			]
 		# Except for virtual buffers, do not proceed if we do have help messages from MRO lookup.
 		# Additional constraints.
 		# Just in case browse mode is active.
@@ -136,6 +129,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		helpMessages = []
 		if isinstance(curObj.treeInterceptor, BrowseModeDocumentTreeInterceptor):
 			return None
+		if hasattr(curObj, "helpText"):
+			helpMessages.append(curObj.helpText)
 		for entry in curObj.__class__.__mro__:
 			clsName = str(entry).split("'")[1]
 			if clsName in objectsHelpMessages:

--- a/addon/globalPlugins/controlUsageAssistant/__init__.py
+++ b/addon/globalPlugins/controlUsageAssistant/__init__.py
@@ -44,14 +44,15 @@ _: Callable[[str], str]
 # before resorting to role-based messages.
 CUAMROLevel = 0
 
+
 class EnhancedSuggestion(NVDAObjects.behaviors.InputFieldWithSuggestions):
 
 	def event_suggestionsOpened(self):
 		super().event_suggestionsOpened()
 		self.helpText = (
 			# Translators: help text for search field in Windows 10 and other places.
-		 _("After typing search text, press up or down arrow keys to review list of suggestions.")
-			)
+			_("After typing search text, press up or down arrow keys to review list of suggestions.")
+		)
 
 	def event_suggestionsClosed(self):
 		self.helpText = None

--- a/addon/globalPlugins/controlUsageAssistant/nvdaobjectshelp.py
+++ b/addon/globalPlugins/controlUsageAssistant/nvdaobjectshelp.py
@@ -20,9 +20,13 @@ _: Callable[[str], str]
 # Source: NVDA pull request for issue 2699 (context-sensitive help)
 
 objectsHelpMessages = {
-	"NVDAObjects.behaviors.EditableTextWithSuggestions": _(
+	# "NVDAObjects.behaviors.EditableTextWithSuggestions": _(
 		# Translators: help text for search field in Windows 10 and other places.
-		"After typing search text, press up or down arrow keys to review list of suggestions."
+		# "After typing search text, press up or down arrow keys to review list of suggestions."
+	# ),
+	"NVDAObjects.behaviors.EditableText": _(
+		# Translators: Help message for edit boxes.
+		"Use arrow keys to move the cursor across text. You may type text here."
 	),
 	"NVDAObjects.IAccessible.adobeAcrobat.Document": _(
 		# Translators: Help message for reading Adobe PDF documents.

--- a/addon/globalPlugins/controlUsageAssistant/nvdaobjectshelp.py
+++ b/addon/globalPlugins/controlUsageAssistant/nvdaobjectshelp.py
@@ -21,8 +21,8 @@ _: Callable[[str], str]
 
 objectsHelpMessages = {
 	# "NVDAObjects.behaviors.EditableTextWithSuggestions": _(
-		# Translators: help text for search field in Windows 10 and other places.
-		# "After typing search text, press up or down arrow keys to review list of suggestions."
+	# Translators: help text for search field in Windows 10 and other places.
+	# "After typing search text, press up or down arrow keys to review list of suggestions."
 	# ),
 	"NVDAObjects.behaviors.EditableText": _(
 		# Translators: Help message for edit boxes.


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
fixes issue #19
### Summary of the issue:
Edit boxes are treated as controls which may provide suggestions, but this is not true for many of them.
### Description of how this pull request fixes the issue:
- For all edit boxes, a message informing that arrow keys can be used to move the cursor, and that text maybe typed. Typing text is not supported for all edit boxes (when state is readonly), so the sentence is announced as a possibility.
- A subclass of the `NVDAObjects.behaviors.InputFieldWithSuggestions` is inserted in clsList for edit boxes. When suggestions are opened, the `helpText`attribute has the value of a help message, and None when suggestions are closed. helpText attribute is also used for automatic messages, though the current object maybe spoken when suggestions are shown, so that the automatic help message won't be reported in such cases.

### Testing performed:
Tested locally.

### Known issues with pull request:
Suggestion help message is not provided automatically, since other NVDA messages seems to abort this. More testing will be performed trying to fix this.
### Change log entry:
- Improved support for edit boxes.
